### PR TITLE
feat: add loyalty programs, card surcharges, and discount stacking

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -62,6 +62,22 @@
   min-width: 0;
 }
 
+.loyalty-program-selected {
+  border-color: var(--mantine-color-teal-4);
+  background: color-mix(in srgb, var(--mantine-color-teal-0) 30%, transparent);
+}
+
+.loyalty-brand-avatar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  min-width: 32px;
+  border-radius: 50%;
+  margin-top: 2px;
+}
+
 @media (max-width: 62rem) {
   .leaflet-map,
   .map-panel {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import {
   Text,
   TextInput,
   Title,
+  Tooltip,
 } from '@mantine/core'
 import { IconAlertCircle, IconInfoCircle } from '@tabler/icons-react'
 import { startTransition, useEffect, useState } from 'react'
@@ -31,10 +32,13 @@ import {
   formatFuelCode,
   formatFuelPrice,
 } from './domain/format'
+import { DEFAULT_PRICE_ADJUSTMENTS, LOYALTY_PROGRAMS } from './domain/loyalty'
 import { buildRankedStations } from './domain/ranking'
 import type {
   FillStrategy,
   FuelCode,
+  PaymentCardType,
+  PriceAdjustments,
   RankedStation,
   RoutePlan,
   SortMode,
@@ -238,6 +242,19 @@ function App({ services = defaultServices }: AppProps) {
     'recommended',
   )
 
+  const [loyaltyEnabled, setLoyaltyEnabled] = usePersistentState(
+    'route-aware-fuel-finder:loyalty-enabled',
+    DEFAULT_PRICE_ADJUSTMENTS.enabled,
+  )
+  const [selectedProgramIds, setSelectedProgramIds] = usePersistentState<string[]>(
+    'route-aware-fuel-finder:selected-programs',
+    DEFAULT_PRICE_ADJUSTMENTS.selectedProgramIds,
+  )
+  const [paymentCardType, setPaymentCardType] = usePersistentState<PaymentCardType>(
+    'route-aware-fuel-finder:payment-card-type',
+    DEFAULT_PRICE_ADJUSTMENTS.paymentCardType,
+  )
+
   const [stations, setStations] = useState<Station[]>([])
   const [isStationDatasetLoading, setIsStationDatasetLoading] = useState(true)
   const [stationLoadError, setStationLoadError] = useState<string | null>(null)
@@ -296,6 +313,12 @@ function App({ services = defaultServices }: AppProps) {
     allowedFuelCodes,
   }
 
+  const priceAdjustments: PriceAdjustments = {
+    enabled: loyaltyEnabled,
+    selectedProgramIds,
+    paymentCardType,
+  }
+
   const rankedStations =
     rawPlan && allowedFuelCodes.length > 0
       ? buildRankedStations({
@@ -315,6 +338,7 @@ function App({ services = defaultServices }: AppProps) {
             maxPriceAgeHours,
             sortMode,
           },
+          priceAdjustments,
         })
       : []
 
@@ -701,6 +725,145 @@ function App({ services = defaultServices }: AppProps) {
                   />
                 </Stack>
 
+                <Divider />
+
+                <Stack gap="md">
+                  <Group justify="space-between" align="center">
+                    <Box>
+                      <Title order={2} size="h3">
+                        Discounts and loyalty
+                      </Title>
+                      <Text size="sm" c="dimmed">
+                        Select programs you use. The effective price factors in
+                        discounts and card surcharges.
+                      </Text>
+                    </Box>
+                    <Switch
+                      checked={loyaltyEnabled}
+                      onChange={(event) =>
+                        setLoyaltyEnabled(event.currentTarget.checked)
+                      }
+                      label={loyaltyEnabled ? 'On' : 'Off'}
+                      labelPosition="left"
+                    />
+                  </Group>
+
+                  <NativeSelect
+                    label="Payment card type"
+                    description="Affects surcharges at some stations."
+                    value={paymentCardType}
+                    data={[
+                      { value: 'visa-mastercard', label: 'Visa / Mastercard' },
+                      { value: 'amex', label: 'American Express' },
+                    ]}
+                    onChange={(event) =>
+                      setPaymentCardType(
+                        event.currentTarget.value as PaymentCardType,
+                      )
+                    }
+                    disabled={!loyaltyEnabled}
+                  />
+
+                  <Stack gap="xs">
+                    {LOYALTY_PROGRAMS.map((program) => {
+                      const isSelected = selectedProgramIds.includes(program.id)
+                      const prerequisiteColor =
+                        program.prerequisite === 'free-app'
+                          ? 'green'
+                          : program.prerequisite === 'supermarket-spend'
+                            ? 'blue'
+                            : 'orange'
+                      const prerequisiteLabel =
+                        program.prerequisite === 'free-app'
+                          ? 'Free app'
+                          : program.prerequisite === 'supermarket-spend'
+                            ? 'Supermarket spend'
+                            : 'Paid membership'
+
+                      return (
+                        <Paper
+                          key={program.id}
+                          withBorder
+                          radius="md"
+                          p="sm"
+                          className={
+                            isSelected && loyaltyEnabled
+                              ? 'loyalty-program-selected'
+                              : ''
+                          }
+                        >
+                          <Group gap="sm" wrap="nowrap" align="flex-start">
+                            <Checkbox
+                              checked={isSelected}
+                              onChange={(event) => {
+                                if (event.currentTarget.checked) {
+                                  setSelectedProgramIds([
+                                    ...selectedProgramIds,
+                                    program.id,
+                                  ])
+                                } else {
+                                  setSelectedProgramIds(
+                                    selectedProgramIds.filter(
+                                      (existingId) => existingId !== program.id,
+                                    ),
+                                  )
+                                }
+                              }}
+                              disabled={!loyaltyEnabled}
+                              mt={4}
+                            />
+                            <Box
+                              className="loyalty-brand-avatar"
+                              style={{
+                                backgroundColor: program.brandColor,
+                              }}
+                            >
+                              <Text size="xs" fw={700} c="white" lh={1}>
+                                {program.shortName}
+                              </Text>
+                            </Box>
+                            <Stack gap={4} style={{ flex: 1 }}>
+                              <Group gap="xs" wrap="wrap">
+                                <Text fw={600} size="sm">
+                                  {program.name}
+                                </Text>
+                                <Badge
+                                  size="xs"
+                                  variant="light"
+                                  color={prerequisiteColor}
+                                >
+                                  {prerequisiteLabel}
+                                </Badge>
+                                <Badge size="xs" variant="outline">
+                                  −{program.discountCentsPerLitre} c/L
+                                </Badge>
+                              </Group>
+                              <Text size="xs" c="dimmed">
+                                {program.description}
+                              </Text>
+                              <Text size="xs" c="dimmed" fs="italic">
+                                {program.prerequisiteNote}
+                              </Text>
+                              <Group gap={4}>
+                                {program.applicableBrands.map((brand) => (
+                                  <Badge
+                                    key={brand}
+                                    size="xs"
+                                    variant="dot"
+                                    color="gray"
+                                  >
+                                    {brand}
+                                  </Badge>
+                                ))}
+                              </Group>
+                            </Stack>
+                          </Group>
+                        </Paper>
+                      )
+                    })}
+                  </Stack>
+                </Stack>
+
                 <Button
                   type="submit"
                   loading={planStatus === 'planning'}
@@ -835,8 +998,15 @@ function App({ services = defaultServices }: AppProps) {
 
                         <Stack gap={4} align="flex-end">
                           <Text fw={800} size="xl">
-                            {formatFuelPrice(station.chosenOffer.priceCentsPerLitre)}
+                            {formatFuelPrice(station.effectivePriceCentsPerLitre)}
                           </Text>
+                          {station.discountCentsPerLitre > 0 ? (
+                            <Text size="xs" c="dimmed" td="line-through">
+                              {formatFuelPrice(
+                                station.chosenOffer.priceCentsPerLitre,
+                              )}
+                            </Text>
+                          ) : null}
                           <Badge variant="default">
                             {formatFuelCode(station.chosenOffer.fuelCode)}
                           </Badge>
@@ -884,6 +1054,29 @@ function App({ services = defaultServices }: AppProps) {
                         <Badge variant="light" color="gray">
                           Time penalty {formatCurrency(station.timePenaltyDollars)}
                         </Badge>
+                        {station.appliedProgramName ? (
+                          <Tooltip label={station.appliedProgramName}>
+                            <Badge variant="light" color="teal">
+                              Loyalty −{station.discountCentsPerLitre.toFixed(1)} c/L
+                            </Badge>
+                          </Tooltip>
+                        ) : null}
+                        {station.surchargeCentsPerLitre > 0 ? (
+                          <Badge variant="light" color="red">
+                            Surcharge +{station.surchargeCentsPerLitre.toFixed(1)} c/L
+                          </Badge>
+                        ) : null}
+                        {station.discountCentsPerLitre > 0 ? (
+                          <Badge variant="light" color="teal">
+                            Save{' '}
+                            {formatCurrency(
+                              (station.fillLitres *
+                                station.discountCentsPerLitre) /
+                                100,
+                            )}{' '}
+                            on fill
+                          </Badge>
+                        ) : null}
                       </Group>
                     </Stack>
                   </Card>

--- a/src/domain/loyalty.test.ts
+++ b/src/domain/loyalty.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  bestLoyaltyDiscount,
+  computeEffectivePrice,
+  LOYALTY_PROGRAMS,
+} from './loyalty'
+import type { PriceAdjustments } from './types'
+
+describe('bestLoyaltyDiscount', () => {
+  it('returns null when no programs are selected', () => {
+    const result = bestLoyaltyDiscount('Ampol', [])
+    expect(result).toBeNull()
+  })
+
+  it('returns null when brand does not match any selected program', () => {
+    const result = bestLoyaltyDiscount('BP', ['woolworths-everyday-rewards'])
+    expect(result).toBeNull()
+  })
+
+  it('returns the discount for a matching brand and program', () => {
+    const result = bestLoyaltyDiscount('Ampol', ['woolworths-everyday-rewards'])
+    expect(result).toEqual({
+      discountCentsPerLitre: 4,
+      programName: 'Woolworths Everyday Rewards',
+    })
+  })
+
+  it('returns the highest discount when multiple programs match the same brand', () => {
+    const result = bestLoyaltyDiscount('Ampol', [
+      'woolworths-everyday-rewards',
+      'ampol-app-fuelpay',
+    ])
+    expect(result).toEqual({
+      discountCentsPerLitre: 6,
+      programName: 'Ampol app (FuelPay)',
+    })
+  })
+
+  it('matches brand names case-insensitively', () => {
+    const result = bestLoyaltyDiscount('ampol', ['woolworths-everyday-rewards'])
+    expect(result).toEqual({
+      discountCentsPerLitre: 4,
+      programName: 'Woolworths Everyday Rewards',
+    })
+  })
+
+  it('matches Shell for Coles Flybuys scan', () => {
+    const result = bestLoyaltyDiscount('Shell', ['coles-flybuys-scan'])
+    expect(result).toEqual({
+      discountCentsPerLitre: 4,
+      programName: 'Coles Flybuys (scan)',
+    })
+  })
+
+  it('stacks Coles Flybuys scan and grocery docket at Shell', () => {
+    const result = bestLoyaltyDiscount('Shell', [
+      'coles-flybuys-scan',
+      'coles-grocery-docket',
+    ])
+    expect(result).toEqual({
+      discountCentsPerLitre: 8,
+      programName: 'Coles Flybuys (scan) + Coles grocery docket',
+    })
+  })
+
+  it('picks the stacked group over a lower ungrouped program', () => {
+    const result = bestLoyaltyDiscount('Coles Express', [
+      'coles-flybuys-scan',
+      'coles-grocery-docket',
+    ])
+    expect(result).toEqual({
+      discountCentsPerLitre: 8,
+      programName: 'Coles Flybuys (scan) + Coles grocery docket',
+    })
+  })
+
+  it('does not stack programs without a stackGroup', () => {
+    const result = bestLoyaltyDiscount('Ampol', [
+      'woolworths-everyday-rewards',
+      'nrma-membership',
+    ])
+    // Both are 4 c/L at Ampol but ungrouped — picks the first one found with highest discount
+    expect(result?.discountCentsPerLitre).toBe(4)
+  })
+})
+
+describe('computeEffectivePrice', () => {
+  const baseAdjustments: PriceAdjustments = {
+    enabled: true,
+    selectedProgramIds: [],
+    paymentCardType: 'visa-mastercard',
+  }
+
+  it('returns the listed price unchanged when adjustments are disabled', () => {
+    const result = computeEffectivePrice(200, 'Ampol', {
+      ...baseAdjustments,
+      enabled: false,
+      selectedProgramIds: ['woolworths-everyday-rewards'],
+    })
+
+    expect(result.effectivePriceCentsPerLitre).toBe(200)
+    expect(result.discountCentsPerLitre).toBe(0)
+    expect(result.surchargeCentsPerLitre).toBe(0)
+    expect(result.appliedProgramName).toBeNull()
+  })
+
+  it('applies a loyalty discount to the effective price', () => {
+    const result = computeEffectivePrice(200, 'Ampol', {
+      ...baseAdjustments,
+      selectedProgramIds: ['woolworths-everyday-rewards'],
+    })
+
+    expect(result.effectivePriceCentsPerLitre).toBe(196)
+    expect(result.discountCentsPerLitre).toBe(4)
+    expect(result.appliedProgramName).toBe('Woolworths Everyday Rewards')
+  })
+
+  it('adds an Amex surcharge for BP', () => {
+    const result = computeEffectivePrice(200, 'BP', {
+      ...baseAdjustments,
+      paymentCardType: 'amex',
+    })
+
+    expect(result.surchargeCentsPerLitre).toBe(3)
+    expect(result.effectivePriceCentsPerLitre).toBe(203)
+  })
+
+  it('adds no surcharge for Visa/Mastercard at BP', () => {
+    const result = computeEffectivePrice(200, 'BP', {
+      ...baseAdjustments,
+      paymentCardType: 'visa-mastercard',
+    })
+
+    expect(result.surchargeCentsPerLitre).toBe(0)
+    expect(result.effectivePriceCentsPerLitre).toBe(200)
+  })
+
+  it('combines loyalty discount and Amex surcharge', () => {
+    const result = computeEffectivePrice(200, 'Shell', {
+      ...baseAdjustments,
+      selectedProgramIds: ['coles-flybuys-scan'],
+      paymentCardType: 'amex',
+    })
+
+    expect(result.discountCentsPerLitre).toBe(4)
+    expect(result.surchargeCentsPerLitre).toBe(3)
+    expect(result.effectivePriceCentsPerLitre).toBe(199)
+  })
+
+  it('defaults to zero surcharge for unknown brands', () => {
+    const result = computeEffectivePrice(200, 'Unknown Brand', {
+      ...baseAdjustments,
+      paymentCardType: 'amex',
+    })
+
+    expect(result.surchargeCentsPerLitre).toBe(0)
+    expect(result.effectivePriceCentsPerLitre).toBe(200)
+  })
+
+  it('never produces a negative effective price', () => {
+    const result = computeEffectivePrice(3, 'Ampol', {
+      ...baseAdjustments,
+      selectedProgramIds: ['ampol-app-fuelpay'],
+    })
+
+    expect(result.effectivePriceCentsPerLitre).toBe(0)
+  })
+})
+
+describe('LOYALTY_PROGRAMS data integrity', () => {
+  it('has unique program ids', () => {
+    const ids = LOYALTY_PROGRAMS.map((program) => program.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('every program has at least one applicable brand', () => {
+    for (const program of LOYALTY_PROGRAMS) {
+      expect(program.applicableBrands.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('every program has a positive discount', () => {
+    for (const program of LOYALTY_PROGRAMS) {
+      expect(program.discountCentsPerLitre).toBeGreaterThan(0)
+    }
+  })
+})

--- a/src/domain/loyalty.ts
+++ b/src/domain/loyalty.ts
@@ -75,7 +75,8 @@ export const LOYALTY_PROGRAMS: LoyaltyProgram[] = [
 
 /**
  * Card surcharge rates per fuel station brand.
- * Source: surchargetracker.net (verified May 2025).
+ * Sources: surchargetracker.net (verified May 2025),
+ * Payless Fuel verified via personal transaction (March 2026).
  *
  * Most major chains charge 0% on Visa/Mastercard.
  * Amex surcharges range from 0% to 1.5%.
@@ -87,6 +88,7 @@ export const CARD_SURCHARGES: CardSurchargeEntry[] = [
   { brand: 'BP', visaMastercardPercent: 0, amexPercent: 1.5 },
   { brand: 'Caltex', visaMastercardPercent: 0, amexPercent: 1.5 },
   { brand: 'Coles Express', visaMastercardPercent: 0, amexPercent: 1 },
+  { brand: 'Payless Fuel', visaMastercardPercent: 0, amexPercent: 0 },
   { brand: 'Shell', visaMastercardPercent: 0, amexPercent: 1.5 },
 ]
 

--- a/src/domain/loyalty.ts
+++ b/src/domain/loyalty.ts
@@ -1,0 +1,219 @@
+import type {
+  CardSurchargeEntry,
+  LoyaltyProgram,
+  PaymentCardType,
+  PriceAdjustments,
+} from './types'
+
+export const LOYALTY_PROGRAMS: LoyaltyProgram[] = [
+  {
+    id: 'woolworths-everyday-rewards',
+    name: 'Woolworths Everyday Rewards',
+    shortName: 'WW',
+    description:
+      'Save 4 c/L when you spend $30 or more at Woolworths and scan your Everyday Rewards card at participating stations.',
+    prerequisite: 'supermarket-spend',
+    prerequisiteNote: 'Requires $30+ spend at Woolworths to earn the fuel voucher.',
+    discountCentsPerLitre: 4,
+    applicableBrands: ['Ampol', 'EG Ampol'],
+    brandColor: '#1a8b39',
+  },
+  {
+    id: 'coles-flybuys-scan',
+    name: 'Coles Flybuys (scan)',
+    shortName: 'CF',
+    description:
+      'Save 4 c/L when you scan your Flybuys card at participating Shell and Coles Express stations. No spend required — just scan at the bowser.',
+    prerequisite: 'free-app',
+    prerequisiteNote: 'Free — just scan your Flybuys card at the pump.',
+    discountCentsPerLitre: 4,
+    applicableBrands: ['Shell', 'Coles Express'],
+    brandColor: '#e01a22',
+    stackGroup: 'coles',
+  },
+  {
+    id: 'coles-grocery-docket',
+    name: 'Coles grocery docket',
+    shortName: 'CD',
+    description:
+      'Save an additional 4 c/L when you spend $30 or more at Coles and redeem the grocery docket at Shell or Coles Express. Stacks with Flybuys scan discount.',
+    prerequisite: 'supermarket-spend',
+    prerequisiteNote:
+      'Requires $30+ spend at Coles. Stacks with Flybuys scan discount for up to 8 c/L off.',
+    discountCentsPerLitre: 4,
+    applicableBrands: ['Shell', 'Coles Express'],
+    brandColor: '#e01a22',
+    stackGroup: 'coles',
+  },
+  {
+    id: 'ampol-app-fuelpay',
+    name: 'Ampol app (FuelPay)',
+    shortName: 'AP',
+    description:
+      'Save 6 c/L on your first 3 fills when you pay via FuelPay in the Ampol app. Free to install and sign up.',
+    prerequisite: 'free-app',
+    prerequisiteNote:
+      'Free app — just install and create an account. Introductory offer for the first 3 fills only.',
+    discountCentsPerLitre: 6,
+    applicableBrands: ['Ampol'],
+    brandColor: '#f58220',
+  },
+  {
+    id: 'nrma-membership',
+    name: 'NRMA Membership',
+    shortName: 'NR',
+    description:
+      'Save 4 c/L on regular fuel and up to 5 c/L on premium fuels at participating Ampol stations via the NRMA app.',
+    prerequisite: 'paid-membership',
+    prerequisiteNote:
+      'Requires a paid NRMA membership (roadside assistance). Stacking with supermarket vouchers has not been confirmed.',
+    discountCentsPerLitre: 4,
+    applicableBrands: ['Ampol'],
+    brandColor: '#003478',
+  },
+]
+
+/**
+ * Card surcharge rates per fuel station brand.
+ * Source: surchargetracker.net (verified May 2025).
+ *
+ * Most major chains charge 0% on Visa/Mastercard.
+ * Amex surcharges range from 0% to 1.5%.
+ * Independent/unknown brands default to 0%.
+ */
+export const CARD_SURCHARGES: CardSurchargeEntry[] = [
+  { brand: '7-Eleven', visaMastercardPercent: 0, amexPercent: 0 },
+  { brand: 'Ampol', visaMastercardPercent: 0, amexPercent: 0 },
+  { brand: 'BP', visaMastercardPercent: 0, amexPercent: 1.5 },
+  { brand: 'Caltex', visaMastercardPercent: 0, amexPercent: 1.5 },
+  { brand: 'Coles Express', visaMastercardPercent: 0, amexPercent: 1 },
+  { brand: 'Shell', visaMastercardPercent: 0, amexPercent: 1.5 },
+]
+
+const DEFAULT_SURCHARGE: CardSurchargeEntry = {
+  brand: '',
+  visaMastercardPercent: 0,
+  amexPercent: 0,
+}
+
+function findSurcharge(brand: string): CardSurchargeEntry {
+  return (
+    CARD_SURCHARGES.find(
+      (entry) => entry.brand.toLowerCase() === brand.toLowerCase(),
+    ) ?? DEFAULT_SURCHARGE
+  )
+}
+
+function surchargePercent(
+  surcharge: CardSurchargeEntry,
+  cardType: PaymentCardType,
+): number {
+  return cardType === 'amex'
+    ? surcharge.amexPercent
+    : surcharge.visaMastercardPercent
+}
+
+/**
+ * Returns the best applicable discount in c/L for a station brand,
+ * given the user's selected loyalty programs.
+ *
+ * Programs sharing the same stackGroup have their discounts summed.
+ * Ungrouped programs compete individually. The highest total wins.
+ */
+export function bestLoyaltyDiscount(
+  brand: string,
+  selectedProgramIds: string[],
+): { discountCentsPerLitre: number; programName: string } | null {
+  const matchingPrograms = LOYALTY_PROGRAMS.filter(
+    (program) =>
+      selectedProgramIds.includes(program.id) &&
+      program.applicableBrands.some(
+        (applicableBrand) =>
+          applicableBrand.toLowerCase() === brand.toLowerCase(),
+      ),
+  )
+
+  if (matchingPrograms.length === 0) {
+    return null
+  }
+
+  const groupTotals = new Map<
+    string,
+    { discount: number; names: string[] }
+  >()
+
+  for (const program of matchingPrograms) {
+    const key = program.stackGroup ?? `__solo__${program.id}`
+    const existing = groupTotals.get(key) ?? { discount: 0, names: [] }
+    existing.discount += program.discountCentsPerLitre
+    existing.names.push(program.name)
+    groupTotals.set(key, existing)
+  }
+
+  let bestDiscount = 0
+  let bestName = ''
+
+  for (const group of groupTotals.values()) {
+    if (group.discount > bestDiscount) {
+      bestDiscount = group.discount
+      bestName = group.names.join(' + ')
+    }
+  }
+
+  if (bestDiscount <= 0) {
+    return null
+  }
+
+  return { discountCentsPerLitre: bestDiscount, programName: bestName }
+}
+
+/**
+ * Computes the effective price at a station after loyalty discounts and card surcharges.
+ *
+ * effectivePrice = listedPrice - loyaltyDiscount + cardSurcharge
+ */
+export function computeEffectivePrice(
+  priceCentsPerLitre: number,
+  brand: string,
+  adjustments: PriceAdjustments,
+): {
+  effectivePriceCentsPerLitre: number
+  discountCentsPerLitre: number
+  surchargeCentsPerLitre: number
+  appliedProgramName: string | null
+} {
+  if (!adjustments.enabled) {
+    return {
+      effectivePriceCentsPerLitre: priceCentsPerLitre,
+      discountCentsPerLitre: 0,
+      surchargeCentsPerLitre: 0,
+      appliedProgramName: null,
+    }
+  }
+
+  const loyaltyResult = bestLoyaltyDiscount(brand, adjustments.selectedProgramIds)
+  const discountCentsPerLitre = loyaltyResult?.discountCentsPerLitre ?? 0
+  const appliedProgramName = loyaltyResult?.programName ?? null
+
+  const surchargeEntry = findSurcharge(brand)
+  const percent = surchargePercent(surchargeEntry, adjustments.paymentCardType)
+  const surchargeCentsPerLitre = (priceCentsPerLitre * percent) / 100
+
+  const effectivePriceCentsPerLitre = Math.max(
+    0,
+    priceCentsPerLitre - discountCentsPerLitre + surchargeCentsPerLitre,
+  )
+
+  return {
+    effectivePriceCentsPerLitre,
+    discountCentsPerLitre,
+    surchargeCentsPerLitre,
+    appliedProgramName,
+  }
+}
+
+export const DEFAULT_PRICE_ADJUSTMENTS: PriceAdjustments = {
+  enabled: true,
+  selectedProgramIds: [],
+  paymentCardType: 'visa-mastercard',
+}

--- a/src/domain/ranking.ts
+++ b/src/domain/ranking.ts
@@ -1,6 +1,8 @@
 import { averageAllowedPrice, chooseBestOffer, computeFillLitres, estimatedRangeKm } from './fuel'
+import { computeEffectivePrice, DEFAULT_PRICE_ADJUSTMENTS } from './loyalty'
 import type {
   FillStrategy,
+  PriceAdjustments,
   RankedStation,
   RankingPreferences,
   RoutePlan,
@@ -21,6 +23,7 @@ export interface BuildRankedStationsArgs {
   vehicle: VehicleProfile
   fillStrategy: FillStrategy
   preferences: RankingPreferences
+  priceAdjustments?: PriceAdjustments
 }
 
 export function buildRankedStations({
@@ -31,6 +34,7 @@ export function buildRankedStations({
   vehicle,
   fillStrategy,
   preferences,
+  priceAdjustments = DEFAULT_PRICE_ADJUSTMENTS,
 }: BuildRankedStationsArgs) {
   const referencePrice = averageAllowedPrice(stations, vehicle.allowedFuelCodes)
   const reachableRangeKm = estimatedRangeKm(vehicle)
@@ -51,12 +55,24 @@ export function buildRankedStations({
       }
 
       const ageHours = hoursBetween(now, chosenOffer.updatedAt)
+
+      const {
+        effectivePriceCentsPerLitre,
+        discountCentsPerLitre,
+        surchargeCentsPerLitre,
+        appliedProgramName,
+      } = computeEffectivePrice(
+        chosenOffer.priceCentsPerLitre,
+        station.brand,
+        priceAdjustments,
+      )
+
       const fillLitres = computeFillLitres(
         fillStrategy,
         vehicle,
-        chosenOffer.priceCentsPerLitre,
+        effectivePriceCentsPerLitre,
       )
-      const fillCostDollars = (fillLitres * chosenOffer.priceCentsPerLitre) / 100
+      const fillCostDollars = (fillLitres * effectivePriceCentsPerLitre) / 100
       const detourFuelLitres =
         (metrics.extraDistanceKm * vehicle.consumptionLitresPer100Km) / 100
       const detourFuelCostDollars =
@@ -88,6 +104,10 @@ export function buildRankedStations({
           distanceFromOriginKm: metrics.distanceFromOriginKm,
           ageHours,
           reachable,
+          effectivePriceCentsPerLitre,
+          discountCentsPerLitre,
+          surchargeCentsPerLitre,
+          appliedProgramName,
           excludedReason: 'detour',
         }
       }
@@ -107,6 +127,10 @@ export function buildRankedStations({
           distanceFromOriginKm: metrics.distanceFromOriginKm,
           ageHours,
           reachable,
+          effectivePriceCentsPerLitre,
+          discountCentsPerLitre,
+          surchargeCentsPerLitre,
+          appliedProgramName,
           excludedReason: 'stale',
         }
       }
@@ -137,6 +161,10 @@ export function buildRankedStations({
         distanceFromOriginKm: metrics.distanceFromOriginKm,
         ageHours,
         reachable,
+        effectivePriceCentsPerLitre,
+        discountCentsPerLitre,
+        surchargeCentsPerLitre,
+        appliedProgramName,
       }
     })
     .filter((station): station is RankedStation => station !== null)
@@ -156,7 +184,7 @@ export function buildRankedStations({
     switch (preferences.sortMode) {
       case 'pump-price':
         return (
-          left.chosenOffer.priceCentsPerLitre - right.chosenOffer.priceCentsPerLitre
+          left.effectivePriceCentsPerLitre - right.effectivePriceCentsPerLitre
         )
       case 'extra-time':
         return left.extraDurationMinutes - right.extraDurationMinutes

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -1,5 +1,7 @@
 export type FuelCode = string
 
+export type PaymentCardType = 'visa-mastercard' | 'amex'
+
 export interface Coordinate {
   lat: number
   lng: number
@@ -80,5 +82,36 @@ export interface RankedStation {
   distanceFromOriginKm: number
   ageHours: number
   reachable: boolean
+  effectivePriceCentsPerLitre: number
+  discountCentsPerLitre: number
+  surchargeCentsPerLitre: number
+  appliedProgramName: string | null
   excludedReason?: 'fuel' | 'detour' | 'stale'
+}
+
+export type LoyaltyProgramPrerequisite = 'free-app' | 'supermarket-spend' | 'paid-membership'
+
+export interface LoyaltyProgram {
+  id: string
+  name: string
+  shortName: string
+  description: string
+  prerequisite: LoyaltyProgramPrerequisite
+  prerequisiteNote: string
+  discountCentsPerLitre: number
+  applicableBrands: string[]
+  brandColor: string
+  stackGroup?: string
+}
+
+export interface CardSurchargeEntry {
+  brand: string
+  visaMastercardPercent: number
+  amexPercent: number
+}
+
+export interface PriceAdjustments {
+  enabled: boolean
+  selectedProgramIds: string[]
+  paymentCardType: PaymentCardType
 }


### PR DESCRIPTION
## Summary

Adds loyalty program discounts, card surcharges, and effective price computation so the app can show real out-of-pocket costs rather than just listed pump prices.

Closes #1. Related: #2 (data freshness monitoring), #3 (stacking research).

## Changes

### Domain layer (`src/domain/`)
- **`types.ts`** — New types: `PaymentCardType`, `LoyaltyProgram` (with `stackGroup` for stacking), `CardSurchargeEntry`, `PriceAdjustments`, `LoyaltyProgramPrerequisite`. Extended `RankedStation` with effective price fields.
- **`loyalty.ts`** (new) — Predefined programs (Woolworths Everyday Rewards, Coles Flybuys scan, Coles grocery docket, Ampol FuelPay, NRMA). Card surcharge data for 6 brands. `bestLoyaltyDiscount()` with stack-group summing. `computeEffectivePrice()` combining discounts and surcharges.
- **`ranking.ts`** — Integrates effective prices into station ranking and fill cost.

### Stacking support
Programs sharing the same `stackGroup` have their discounts summed. Currently enabled for:
- **Coles Flybuys scan (4 c/L) + Coles grocery docket (4 c/L) = 8 c/L** at Shell / Coles Express

Other combinations (NRMA + Woolworths, FuelPay + others) are deferred pending research (#3).

### UI (`src/App.tsx`, `src/App.css`)
- "Discounts and loyalty" section with global on/off toggle
- Payment card type selector (Visa/MC vs Amex)
- Program checkboxes with brand-colored avatars and prerequisite badges
- Station cards show effective price with strikethrough on listed price
- Loyalty discount, surcharge, and net savings badges on each card
- All settings persisted in localStorage

### Tests
- 19 tests in `loyalty.test.ts` covering discount selection, stacking, surcharges, effective price, edge cases, and data integrity

## Testing

All 55 tests pass. Lint clean.