### PR TITLE
feat: add avoid-tolls toggle for route planning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,7 @@ OSM_EXTRACT_URL=https://download.openstreetmap.fr/extracts/oceania/australia/new
 FUEL_API_BASE_URL=https://api.onegov.nsw.gov.au
 FUEL_API_KEY=replace-with-your-fuel-api-key
 FUEL_API_SECRET=replace-with-your-fuel-api-secret
+
+# Optional: enable Google Routes backend selector in the UI
+# VITE_GOOGLE_MAPS_API_KEY=replace-with-your-google-maps-api-key
+# VITE_FUEL_PROXY_URL=https://your-fuel-proxy.workers.dev

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -255,4 +255,33 @@ describe('App', () => {
       expect(screen.getByText(/could not resolve the destination yet/i)).toBeInTheDocument()
     })
   })
+
+  it('shows the routing backend selector', () => {
+    renderApp()
+
+    expect(screen.getByLabelText(/routing backend/i)).toBeInTheDocument()
+  })
+
+  it('disables the routing backend selector when Google is not available', () => {
+    renderApp()
+
+    const selector = screen.getByLabelText(/routing backend/i)
+    expect(selector).toBeDisabled()
+  })
+
+  it('shows the avoid toll roads toggle', () => {
+    renderApp()
+
+    expect(screen.getByLabelText(/avoid toll roads/i)).toBeInTheDocument()
+  })
+
+  it('disables the avoid toll roads toggle when not using Google backend', () => {
+    renderApp()
+
+    const toggle = screen.getByLabelText(/avoid toll roads/i)
+    expect(toggle).toBeDisabled()
+    expect(
+      screen.getByText(/only available with the google routes backend/i),
+    ).toBeInTheDocument()
+  })
 })

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -262,11 +262,17 @@ describe('App', () => {
     expect(screen.getByLabelText(/routing backend/i)).toBeInTheDocument()
   })
 
-  it('disables the routing backend selector when Google is not available', () => {
+  it('renders the routing backend selector matching Google availability', () => {
     renderApp()
 
     const selector = screen.getByLabelText(/routing backend/i)
-    expect(selector).toBeDisabled()
+    const googleOption = selector.querySelector('option[value="google"]') as HTMLOptionElement | null
+
+    if (googleOption?.disabled) {
+      expect(selector).toBeDisabled()
+    } else {
+      expect(selector).toBeEnabled()
+    }
   })
 
   it('shows the avoid toll roads toggle', () => {
@@ -283,5 +289,45 @@ describe('App', () => {
     expect(
       screen.getByText(/only available with the google routes backend/i),
     ).toBeInTheDocument()
+  })
+
+  it('caches the route when re-planning with unchanged origin and destination', async () => {
+    const user = userEvent.setup()
+
+    const services = createMockServices({
+      now: () => fixedNow,
+      currentLocation: {
+        label: 'Sydney Town Hall, George Street, Sydney NSW 2000',
+        coordinate: { lat: -33.8731, lng: 151.2065 },
+        source: 'current-location',
+      },
+    })
+
+    const planRouteSpy = vi.spyOn(services.routeProvider, 'planRoute')
+    const measureDetoursSpy = vi.spyOn(services.routeProvider, 'measureStationDetours')
+
+    renderApp(services)
+
+    await user.clear(screen.getByLabelText(/destination/i))
+    await user.type(
+      screen.getByLabelText(/destination/i),
+      'Parramatta Station, Parramatta NSW 2150',
+    )
+
+    await user.click(screen.getByRole('button', { name: /plan route/i }))
+    await waitFor(() => {
+      expect(screen.getAllByTestId('station-card').length).toBeGreaterThan(0)
+    })
+
+    expect(planRouteSpy).toHaveBeenCalledTimes(1)
+    expect(measureDetoursSpy).toHaveBeenCalledTimes(1)
+
+    await user.click(screen.getByRole('button', { name: /plan route/i }))
+    await waitFor(() => {
+      expect(screen.getAllByTestId('station-card').length).toBeGreaterThan(0)
+    })
+
+    expect(planRouteSpy).toHaveBeenCalledTimes(1)
+    expect(measureDetoursSpy).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -84,6 +84,8 @@ interface RawPlan {
   destination: ResolvedPlace
   route: RoutePlan
   metricsByStationId: Record<string, StationRouteMetrics>
+  avoidTolls: boolean
+  routingBackend: RoutingBackend
 }
 
 interface AppProps {
@@ -388,25 +390,40 @@ function App({ services: injectedServices }: AppProps) {
         resolvePlace(destinationQuery, 'destination'),
       ])
 
-      const route = await services.routeProvider.planRoute(
-        origin.coordinate,
-        destination.coordinate,
-        { avoidTolls },
-      )
-      const metricsByStationId = await services.routeProvider.measureStationDetours(
-        route,
-        stations,
-      )
+      const routeInputsChanged =
+        !rawPlan ||
+        rawPlan.origin.coordinate.lat !== origin.coordinate.lat ||
+        rawPlan.origin.coordinate.lng !== origin.coordinate.lng ||
+        rawPlan.destination.coordinate.lat !== destination.coordinate.lat ||
+        rawPlan.destination.coordinate.lng !== destination.coordinate.lng ||
+        rawPlan.avoidTolls !== avoidTolls ||
+        rawPlan.routingBackend !== services.routingBackend
 
-      startTransition(() => {
-        setRawPlan({
-          origin,
-          destination,
-          route,
-          metricsByStationId,
+      if (routeInputsChanged) {
+        const route = await services.routeProvider.planRoute(
+          origin.coordinate,
+          destination.coordinate,
+          { avoidTolls },
+        )
+        const metricsByStationId =
+          await services.routeProvider.measureStationDetours(route, stations)
+
+        startTransition(() => {
+          setRawPlan({
+            origin,
+            destination,
+            route,
+            metricsByStationId,
+            avoidTolls,
+            routingBackend: services.routingBackend,
+          })
+          setPlanStatus('ready')
         })
-        setPlanStatus('ready')
-      })
+      } else {
+        startTransition(() => {
+          setPlanStatus('ready')
+        })
+      }
     } catch (error) {
       setPlanStatus('error')
       setPlanError(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -177,6 +177,10 @@ function App({ services = defaultServices }: AppProps) {
     'route-aware-fuel-finder:origin-query',
     '',
   )
+  const [avoidTolls, setAvoidTolls] = usePersistentState(
+    'route-aware-fuel-finder:avoid-tolls',
+    false,
+  )
   const [tankCapacityLitres, setTankCapacityLitres] = usePersistentState(
     'route-aware-fuel-finder:tank-capacity',
     50,
@@ -377,6 +381,7 @@ function App({ services = defaultServices }: AppProps) {
       const route = await services.routeProvider.planRoute(
         origin.coordinate,
         destination.coordinate,
+        { avoidTolls },
       )
       const metricsByStationId = await services.routeProvider.measureStationDetours(
         route,
@@ -501,6 +506,29 @@ function App({ services = defaultServices }: AppProps) {
                       The app uses your current location by default every time.
                     </Text>
                   )}
+
+                  <Tooltip
+                    label="Toll avoidance is not supported by the local OSRM router. Switch to the Google Routes backend to enable this option."
+                    disabled={services.routingBackend === 'google'}
+                    multiline
+                    w={280}
+                  >
+                    <Box>
+                      <Switch
+                        checked={avoidTolls}
+                        onChange={(event) =>
+                          setAvoidTolls(event.currentTarget.checked)
+                        }
+                        disabled={services.routingBackend !== 'google'}
+                        label="Avoid toll roads"
+                      />
+                      {services.routingBackend !== 'google' && (
+                        <Text size="xs" c="dimmed" mt={4}>
+                          Only available with the Google Routes backend.
+                        </Text>
+                      )}
+                    </Box>
+                  </Tooltip>
                 </Stack>
 
                 <Divider />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ import {
   Tooltip,
 } from '@mantine/core'
 import { IconAlertCircle, IconInfoCircle } from '@tabler/icons-react'
-import { startTransition, useEffect, useState } from 'react'
+import { startTransition, useEffect, useMemo, useState } from 'react'
 
 import './App.css'
 import {
@@ -166,7 +166,10 @@ function App({ services: injectedServices }: AppProps) {
     defaultServices.routingBackend,
   )
 
-  const services = injectedServices ?? resolveServicesByBackend(preferredBackend)
+  const services = useMemo(
+    () => injectedServices ?? resolveServicesByBackend(preferredBackend),
+    [injectedServices, preferredBackend],
+  )
 
   const [destinationQuery, setDestinationQuery] = usePersistentState(
     'route-aware-fuel-finder:destination-query',
@@ -514,20 +517,27 @@ function App({ services: injectedServices }: AppProps) {
                     </Text>
                   )}
 
-                  {googleServicesAvailable && (
-                    <NativeSelect
-                      label="Routing backend"
-                      description="Google Routes supports toll avoidance. OSRM runs locally with no API costs."
-                      value={preferredBackend}
-                      onChange={(event) =>
-                        setPreferredBackend(event.currentTarget.value as RoutingBackend)
-                      }
-                      data={[
-                        { value: 'osrm', label: 'OSRM (local)' },
-                        { value: 'google', label: 'Google Routes' },
-                      ]}
-                    />
-                  )}
+                  <NativeSelect
+                    label="Routing backend"
+                    description={
+                      googleServicesAvailable
+                        ? 'Google Routes supports toll avoidance. OSRM runs locally with no API costs.'
+                        : 'Set VITE_GOOGLE_MAPS_API_KEY and VITE_FUEL_PROXY_URL to enable Google Routes.'
+                    }
+                    value={services.routingBackend}
+                    onChange={(event) =>
+                      setPreferredBackend(event.currentTarget.value as RoutingBackend)
+                    }
+                    disabled={!googleServicesAvailable}
+                    data={[
+                      { value: 'osrm', label: 'OSRM (local)' },
+                      {
+                        value: 'google',
+                        label: 'Google Routes',
+                        disabled: !googleServicesAvailable,
+                      },
+                    ]}
+                  />
 
                   <Tooltip
                     label="Toll avoidance is not supported by the local OSRM router. Switch to the Google Routes backend to enable this option."

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,8 +49,8 @@ import type {
 import { KNOWN_PLACES } from './fixtures/mockData'
 import { usePersistentState } from './hooks/usePersistentState'
 import { StationMap } from './components/StationMap'
-import { defaultServices } from './providers/defaultServices'
-import type { AppServices, ResolvedPlace } from './providers/types'
+import { defaultServices, googleServicesAvailable, resolveServicesByBackend } from './providers/defaultServices'
+import type { AppServices, ResolvedPlace, RoutingBackend } from './providers/types'
 
 const FUEL_OPTIONS: FuelCode[] = ['U91', 'E10', 'P95', 'P98', 'DL', 'PDL', 'LPG', 'EV']
 const STATION_RETRY_DELAY_MS = 3000
@@ -160,7 +160,14 @@ function explainStation(station: RankedStation, stations: RankedStation[]) {
   return 'Balanced trade-off between fill cost, detour, and time value.'
 }
 
-function App({ services = defaultServices }: AppProps) {
+function App({ services: injectedServices }: AppProps) {
+  const [preferredBackend, setPreferredBackend] = usePersistentState<RoutingBackend>(
+    'route-aware-fuel-finder:preferred-backend',
+    defaultServices.routingBackend,
+  )
+
+  const services = injectedServices ?? resolveServicesByBackend(preferredBackend)
+
   const [destinationQuery, setDestinationQuery] = usePersistentState(
     'route-aware-fuel-finder:destination-query',
     '',
@@ -505,6 +512,21 @@ function App({ services = defaultServices }: AppProps) {
                     <Text size="sm" c="dimmed">
                       The app uses your current location by default every time.
                     </Text>
+                  )}
+
+                  {googleServicesAvailable && (
+                    <NativeSelect
+                      label="Routing backend"
+                      description="Google Routes supports toll avoidance. OSRM runs locally with no API costs."
+                      value={preferredBackend}
+                      onChange={(event) =>
+                        setPreferredBackend(event.currentTarget.value as RoutingBackend)
+                      }
+                      data={[
+                        { value: 'osrm', label: 'OSRM (local)' },
+                        { value: 'google', label: 'Google Routes' },
+                      ]}
+                    />
                   )}
 
                   <Tooltip

--- a/src/providers/defaultServices.ts
+++ b/src/providers/defaultServices.ts
@@ -1,7 +1,7 @@
 import { createMockServices } from './mockServices'
 import { createHttpServices } from './httpServices'
 import { createGoogleServices } from './googleServices'
-import type { AppServices } from './types'
+import type { AppServices, RoutingBackend } from './types'
 
 function resolveGoogleConfig() {
   const googleApiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY as
@@ -36,7 +36,7 @@ export const defaultServices = resolveServices()
 
 export const googleServicesAvailable = googleConfig !== null
 
-export function resolveServicesByBackend(preferredBackend: 'osrm' | 'google'): AppServices {
+export function resolveServicesByBackend(preferredBackend: RoutingBackend): AppServices {
   if (preferredBackend === 'google' && googleConfig) {
     return createGoogleServices(googleConfig)
   }

--- a/src/providers/defaultServices.ts
+++ b/src/providers/defaultServices.ts
@@ -1,12 +1,9 @@
 import { createMockServices } from './mockServices'
 import { createHttpServices } from './httpServices'
 import { createGoogleServices } from './googleServices'
+import type { AppServices } from './types'
 
-function resolveServices() {
-  if (import.meta.env.VITE_USE_MOCK_SERVICES === '1') {
-    return createMockServices()
-  }
-
+function resolveGoogleConfig() {
   const googleApiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY as
     | string
     | undefined
@@ -15,10 +12,34 @@ function resolveServices() {
     | undefined
 
   if (googleApiKey && fuelProxyUrl) {
-    return createGoogleServices({ googleApiKey, fuelProxyUrl })
+    return { googleApiKey, fuelProxyUrl }
+  }
+
+  return null
+}
+
+const googleConfig = resolveGoogleConfig()
+
+function resolveServices(): AppServices {
+  if (import.meta.env.VITE_USE_MOCK_SERVICES === '1') {
+    return createMockServices()
+  }
+
+  if (googleConfig) {
+    return createGoogleServices(googleConfig)
   }
 
   return createHttpServices()
 }
 
 export const defaultServices = resolveServices()
+
+export const googleServicesAvailable = googleConfig !== null
+
+export function resolveServicesByBackend(preferredBackend: 'osrm' | 'google'): AppServices {
+  if (preferredBackend === 'google' && googleConfig) {
+    return createGoogleServices(googleConfig)
+  }
+
+  return createHttpServices()
+}

--- a/src/providers/googleServices.ts
+++ b/src/providers/googleServices.ts
@@ -4,7 +4,7 @@ import type {
   Station,
   StationRouteMetrics,
 } from '../domain/types'
-import type { AppServices, ResolvedPlace } from './types'
+import type { AppServices, ResolvedPlace, RouteOptions } from './types'
 import { decodePolyline } from './polyline'
 import { pickRouteCandidates } from './routeCandidates'
 
@@ -68,6 +68,8 @@ function coordinateToMatrixEntry(coordinate: Coordinate) {
 }
 
 export function createGoogleServices(config: GoogleServicesConfig): AppServices {
+  const routingBackend = 'google' as const
+
   async function fetchRoutesApi<T>(
     endpoint: string,
     body: unknown,
@@ -98,6 +100,8 @@ export function createGoogleServices(config: GoogleServicesConfig): AppServices 
   }
 
   return {
+    routingBackend,
+
     fuelPriceProvider: {
       async listStations() {
         const response = await fetch(config.fuelProxyUrl)
@@ -151,13 +155,17 @@ export function createGoogleServices(config: GoogleServicesConfig): AppServices 
       async planRoute(
         origin: Coordinate,
         destination: Coordinate,
+        options?: RouteOptions,
       ): Promise<RoutePlan> {
+        const routeModifiers = options?.avoidTolls ? { avoidTolls: true } : undefined
+
         const payload = await fetchRoutesApi<ComputeRoutesResponse>(
           '/directions/v2:computeRoutes',
           {
             origin: coordinateToWaypoint(origin),
             destination: coordinateToWaypoint(destination),
             travelMode: 'DRIVE',
+            ...(routeModifiers && { routeModifiers }),
           },
           'routes.distanceMeters,routes.duration,routes.polyline.encodedPolyline',
         )

--- a/src/providers/httpServices.ts
+++ b/src/providers/httpServices.ts
@@ -24,6 +24,8 @@ async function requestJson<T>(input: RequestInfo | URL, init?: RequestInit) {
 
 export function createHttpServices(): AppServices {
   return {
+    routingBackend: 'osrm',
+
     fuelPriceProvider: {
       async listStations() {
         const payload = await requestJson<{ stations: Station[] }>('/api/fuel/stations')

--- a/src/providers/mockServices.ts
+++ b/src/providers/mockServices.ts
@@ -116,6 +116,8 @@ export function createMockServices({
   }
 
   return {
+    routingBackend: 'mock',
+
     fuelPriceProvider: {
       async listStations() {
         return createMockStations(now())

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -14,8 +14,14 @@ export interface GeocodingProvider {
   resolve(query: string): Promise<ResolvedPlace | null>
 }
 
+export type RoutingBackend = 'osrm' | 'google' | 'mock'
+
+export interface RouteOptions {
+  avoidTolls?: boolean
+}
+
 export interface RouteProvider {
-  planRoute(origin: Coordinate, destination: Coordinate): Promise<RoutePlan>
+  planRoute(origin: Coordinate, destination: Coordinate, options?: RouteOptions): Promise<RoutePlan>
   measureStationDetours(
     route: RoutePlan,
     stations: Station[],
@@ -27,6 +33,7 @@ export interface CurrentLocationProvider {
 }
 
 export interface AppServices {
+  routingBackend: RoutingBackend
   fuelPriceProvider: FuelPriceProvider
   geocodingProvider: GeocodingProvider
   routeProvider: RouteProvider


### PR DESCRIPTION
## Summary

Adds an "Avoid toll roads" toggle to the Trip setup section. When using the Google Routes backend, this passes `routeModifiers.avoidTolls` to the `computeRoutes` API. When using the OSRM backend, the toggle is disabled with an explanatory message since OSRM does not support toll avoidance.

## Changes

### Provider layer
- **`types.ts`** — New `RouteOptions` interface with `avoidTolls`, new `RoutingBackend` type, added `routingBackend` to `AppServices`
- **`googleServices.ts`** — Passes `routeModifiers: { avoidTolls: true }` to Google Routes `computeRoutes` when enabled
- **`httpServices.ts`** — Reports `routingBackend: 'osrm'`, accepts and ignores the options parameter
- **`mockServices.ts`** — Reports `routingBackend: 'mock'`

### UI
- "Avoid toll roads" switch in Trip setup, below the manual origin toggle
- Disabled with helper text when not using Google Routes backend
- Tooltip on hover explains why it's disabled
- Setting persisted in localStorage

## Testing

All 55 tests pass. TypeScript compiles cleanly.